### PR TITLE
Improved the travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,11 @@
 language: php
 
+sudo: false
+
+cache:
+  directories:
+    - $HOME/.composer/cache
+
 php:
   - 5.5
   - 5.6
@@ -8,7 +14,7 @@ php:
 
 before_script:
   - composer self-update
-  - composer update --prefer-source --dev
+  - composer update
 
 script:
   - ./vendor/bin/phpunit --coverage-clover ./build/logs/clover.xml --exclude-group Functional,Performance


### PR DESCRIPTION
- switch to the faster container-based infrastructure
- keep the composer cache between builds, making dist downloads faster for stable release (and less likely to hit the github rate limit forcing to fallback to a git clone)