### PR TITLE
Run behat in strict mode on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,4 @@ script:
 #  - ./vendor/bin/phpunit --group=Functional
 #  - ./vendor/bin/phpunit --group=Performance
   - ./vendor/bin/phpcs --standard=PSR2 ./src/ ./test/
-  - ./vendor/bin/behat
+  - ./vendor/bin/behat --strict


### PR DESCRIPTION
This make scenario fail when a step which is not implemented (PendingException) is used in them.