### PR TITLE
fix errors and warnings in PHPCBF

### DIFF
--- a/src/ChangeSet/IdentityMap/SimpleIdentityMap.php
+++ b/src/ChangeSet/IdentityMap/SimpleIdentityMap.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace ChangeSet\IdentityMap;
+
 use ChangeSet\IdentityExtractor\IdentityExtractorInterface;
 
 /**
@@ -31,7 +32,8 @@ class SimpleIdentityMap
             return false;
         }
 
-        $class = get_class($object); // @todo introduce something to resolve the correct class name instead, as `get_class` is too naive
+        // @todo introduce something to resolve the correct class name instead, as `get_class` is too naive
+        $class = get_class($object); 
 
         if (null === $identity) {
             $encodedIdentity  = $this->identityExtractor->getEncodedIdentifier($object);


### PR DESCRIPTION
FILE: ...ramius/ChangeSet/src/ChangeSet/IdentityMap/SimpleIdentityMap.php
----------------------------------------------------------------------
FOUND 1 ERROR AND 1 WARNING AFFECTING 2 LINES
----------------------------------------------------------------------
  3 | ERROR   | [x] There must be one blank line after the namespace
    |         |     declaration
 34 | WARNING | [ ] Line exceeds 120 characters; contains 136
    |         |     characters
----------------------------------------------------------------------
PHPCBF CAN FIX THE 1 MARKED SNIFF VIOLATIONS AUTOMATICALLY
----------------------------------------------------------------------