### PR TITLE
fix PHPCBF warning

### DIFF
--- a/src/ChangeSet/IdentityMap/SimpleIdentityMap.php
+++ b/src/ChangeSet/IdentityMap/SimpleIdentityMap.php
@@ -33,7 +33,7 @@ class SimpleIdentityMap
         }
 
         // @todo introduce something to resolve the correct class name instead, as `get_class` is too naive
-        $class = get_class($object); 
+        $class = get_class($object);
 
         if (null === $identity) {
             $encodedIdentity  = $this->identityExtractor->getEncodedIdentifier($object);


### PR DESCRIPTION
1.41s$ ./vendor/bin/phpcs --standard=PSR2 ./src/ ./test/
## FILE: ...ramius/ChangeSet/src/ChangeSet/IdentityMap/SimpleIdentityMap.php
## FOUND 1 ERROR AFFECTING 1 LINE
##  36 | ERROR | [x] Whitespace found at end of line
## PHPCBF CAN FIX THE 1 MARKED SNIFF VIOLATIONS AUTOMATICALLY
